### PR TITLE
Capitalize Hg, as a chemical symbol.

### DIFF
--- a/android.html
+++ b/android.html
@@ -91,7 +91,7 @@
           <p>This is the last big step. In a terminal, in your <code>src/</code> directory, enter:</p>  
           <p><code>hg clone http://hg.mozilla.org/mozilla-central/</code></p>
           <p>... and enter. This step uses mercurial to pull down the Firefox for Android source code from Mozilla-Central.
-             <code>hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
+             <code>Hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
           <p>While you’re waiting for that process to finish, take a look at <a target="_blank" href="http://mozilla-version-control-tools.readthedocs.org/en/latest/hgmozilla/index.html">our Mercurial documentation</a>.</p>   
           <p>It explains how we use version control at Mozilla to manage our code and land changes to our source tree.</p>  
     </div>

--- a/desktop-linux.html
+++ b/desktop-linux.html
@@ -71,7 +71,7 @@
           <p>This is the last big step. In a terminal, in your <code>src/</code> directory, enter:</p>  
           <p><code>hg clone http://hg.mozilla.org/mozilla-central/</code></p>  
           <p>... and enter. This step uses mercurial to pull down the Firefox source code from Mozilla-Central.
-             <code>hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
+             <code>Hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
           <p>While you’re waiting for that to finish, take a look at <a target="_blank" href="http://mozilla-version-control-tools.readthedocs.org/en/latest/hgmozilla/index.html">our Mercurial documentation</a>.</p>   
           <p>It explains how we use version control at Mozilla to manage our code and land changes to our source tree.</p>  
     </div>

--- a/desktop-osx.html
+++ b/desktop-osx.html
@@ -73,7 +73,7 @@
           <p>This is the last big step. In a terminal, in your <code>src/</code> directory, enter:</p>  
           <p><code>hg clone http://hg.mozilla.org/mozilla-central/</code></p>  
           <p>... and enter. This step uses mercurial to pull down the Firefox source code from Mozilla-Central.
-             <code>hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
+             <code>Hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
           <p>While you’re waiting for that to finish, take a look at <a target="_blank" href="http://mozilla-version-control-tools.readthedocs.org/en/latest/hgmozilla/index.html">our Mercurial documentation</a>.</p>   
           <p>It explains how we use version control at Mozilla to manage our code and land changes to our source tree.</p>  
     </div>

--- a/desktop-windows.html
+++ b/desktop-windows.html
@@ -66,7 +66,7 @@
           <p>This is the last big step. Double-clicking the shortcut you’ve created will open a terminal window; start by creating a "mozilla-source" directory off of <code>C:\</code> and cd into it like so</p>  
           <p><code>cd c:/; mkdir mozilla-source; cd mozilla-source</code> </p>
           <p>Next you can pull down the Firefox source code with Mercurial, using this command: <code>hg clone https://hg.mozilla.org/mozilla-central</code> </p>
-          <p><code>hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
+          <p><code>Hg</code> is the chemical symbol for mercury, if you’re wondering.</p> 
           <p>While you’re waiting for that process to finish, take a look at <a target="_blank" href="http://mozilla-version-control-tools.readthedocs.org/en/latest/hgmozilla/index.html">our Mercurial documentation</a>.</p>   
           <p>It explains how we use version control at Mozilla to manage our code and land changes to our source tree.</p>  
     </div>


### PR DESCRIPTION
Closes #10